### PR TITLE
Change feature gate to match macro rename

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![doc(html_root_url = "https://docs.rs/tinypci")]
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #![cfg_attr(not(feature="std"), no_std)]
 


### PR DESCRIPTION
Oops! In order to use `llvm_asm!` you need to change the feature gate to match the macro change ― sorry, forgot to do that when sending the pull request earlier