### PR TITLE
Switch to rust-lang/rust#72016 `asm!` syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ unsafe fn read_from_port(port: u16) -> u32 {
 // extracted from the `x86_64` crate.
 #[inline]
 unsafe fn write_to_port(port: u16, value: u32) {
-    asm!("outl eax, dx", out("dx") port, in("eax") value);
+    asm!("outl dx, eax", out("dx") port, in("eax") value);
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![doc(html_root_url = "https://docs.rs/tinypci")]
 
-#![feature(llvm_asm)]
+#![feature(asm)]
 
 #![cfg_attr(not(feature="std"), no_std)]
 
@@ -30,14 +30,14 @@ pub use enums::*;
 #[inline]
 unsafe fn read_from_port(port: u16) -> u32 {
     let value: u32;
-    llvm_asm!("inl %dx, %eax" : "={eax}"(value) : "{dx}"(port) :: "volatile");
+    asm!("inl eax, dx", out("eax") value, in("dx") port);
     value
 }
 
 // extracted from the `x86_64` crate.
 #[inline]
 unsafe fn write_to_port(port: u16, value: u32) {
-    llvm_asm!("outl %eax, %dx" :: "{dx}"(port), "{eax}"(value) :: "volatile");
+    asm!("outl eax, dx", out("dx") port, in("eax") value);
 }
 
 


### PR DESCRIPTION
Per rust-lang/rust#72016, `asm!` is back ― but it has a [brand-new syntax](https://doc.rust-lang.org/nightly/unstable-book/library-features/asm.html) associated with it that includes, among other things, `intel` and `volatile` by default. As if that's not enough, they're now deprecating `llvm_asm!` upstream in favor of this.