### PR TITLE
The `asm!` macro now needs to be `use`d for this to compile

### DIFF
--- a/src/port.rs
+++ b/src/port.rs
@@ -3,6 +3,12 @@ use std::marker::PhantomData;
 #[cfg(not(feature="std"))]
 use core::marker::PhantomData;
 
+#[cfg(feature="std")]
+use std::arch::asm;
+
+#[cfg(not(feature="std"))]
+use core::arch::asm;
+
 /// Trait for limiting [Port] to only being able to read/write u8/16/32.
 pub(crate) trait PortRW {
     /// Read a value (self) from the port


### PR DESCRIPTION
Now that `asm!` has become a stable feature, one needs to `use core::arch::asm` in order to, well, use it. Otherwise a bunch of errors get thrown by the compiler.

So, time to make this crate usable again.